### PR TITLE
Do not run buildbot as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,9 @@ USER root
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN pip3 --no-cache-dir install 'buildbot-tyrian-theme'
+
+# We cannot RUN useradd -d /var/lib/buildbot buildbot since useradd is not present
+# So let's create user ad hand
+RUN echo 'buildbot:x:1000:1000:Buildbot:/var/lib/buildbot:/sbin/nologin' >> /etc/passwd
+RUN chown -R buildbot /var/lib/buildbot
+USER buildbot


### PR DESCRIPTION
Signed-off-by: Corentin Labbe <clabbe@baylibre.com>