### PR TITLE
Copy buildbot-config.yaml in master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ RUN pip3 --no-cache-dir install 'buildbot-tyrian-theme'
 RUN echo 'buildbot:x:1000:1000:Buildbot:/var/lib/buildbot:/sbin/nologin' >> /etc/passwd
 RUN chown -R buildbot /var/lib/buildbot
 USER buildbot
+COPY buildbot-config.yaml /var/lib/buildbot

--- a/buildbot-config.yaml.example
+++ b/buildbot-config.yaml.example
@@ -1,0 +1,22 @@
+workers:
+  - name: worker0
+    pass: tobechanged
+    toolchains:
+      amd64:
+        clang: True
+        gcc: True
+      arm:
+        clang: True
+        gcc: True
+      arm64:
+        clang: True
+        gcc: True
+      ppc64:
+        clang: True
+        gcc: True
+      sparc:
+        clang: True
+        gcc: True
+    gentoo_sources: True
+    other_sources: True
+    eclass_change: True


### PR DESCRIPTION
buildboot worker will be now configured via buildbot-config.yaml, so we need to copy it.
Add also a buildbot-config.yaml example.