### PR TITLE
refactor: switch from the deprecated MAINTAINER to LABEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM        buildbot/buildbot-master:v4.3.0
-MAINTAINER  alicef@gentoo.org
+LABEL       org.opencontainers.image.authors="alicef@gentoo.org"
 
 USER root
 # This will make apt-get install without question


### PR DESCRIPTION
This is a pretty minor point, but newer builds of docker produce warnings whenever you build using the `MAINTAINER` Dockerfile key.

```
 - MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 2)
```

the recommendation is to use this LABEL instead:
https://docs.docker.com/reference/dockerfile/#maintainer-deprecated
```
LABEL org.opencontainers.image.authors="your email"
```